### PR TITLE
fix: pointer alignment error on type cast used in flashfs blank_check

### DIFF
--- a/src/drivers/linux_pwm_out/linux_pwm_out.cpp
+++ b/src/drivers/linux_pwm_out/linux_pwm_out.cpp
@@ -113,7 +113,7 @@ static void start();
 
 static void stop();
 
-static void task_main_trampoline(int argc, char *argv[]);
+static int task_main_trampoline(int argc, char *argv[]);
 
 static void subscribe();
 
@@ -452,9 +452,10 @@ void task_main(int argc, char *argv[])
 
 }
 
-void task_main_trampoline(int argc, char *argv[])
+int task_main_trampoline(int argc, char *argv[])
 {
 	task_main(argc, argv);
+	return 0;
 }
 
 void start()

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -303,7 +303,7 @@ private:
 	/**
 	 * Trampoline to the worker task
 	 */
-	static void		task_main_trampoline(int argc, char *argv[]);
+	static int		task_main_trampoline(int argc, char *argv[]);
 
 	/**
 	 * worker task
@@ -892,10 +892,11 @@ PX4IO::init()
 	return OK;
 }
 
-void
+int 
 PX4IO::task_main_trampoline(int argc, char *argv[])
 {
 	g_dev->task_main();
+	return 0;
 }
 
 void

--- a/src/drivers/qurt/fc_addon/mpu_spi/mpu9x50_main.cpp
+++ b/src/drivers/qurt/fc_addon/mpu_spi/mpu9x50_main.cpp
@@ -137,7 +137,7 @@ static void usage();
 static void stop();
 
 /** task main trampoline function */
-static void	task_main_trampoline(int argc, char *argv[]);
+static int	task_main_trampoline(int argc, char *argv[]);
 
 /** mpu9x50 measurement thread primary entry point */
 static void task_main(int argc, char *argv[]);
@@ -535,10 +535,11 @@ exit:
 }
 
 /** mpu9x50 main entrance */
-void task_main_trampoline(int argc, char *argv[])
+int task_main_trampoline(int argc, char *argv[])
 {
 	PX4_WARN("task_main_trampoline");
 	task_main(argc, argv);
+	return 0;
 }
 
 void start()

--- a/src/drivers/qurt/fc_addon/rc_receiver/rc_receiver_main.cpp
+++ b/src/drivers/qurt/fc_addon/rc_receiver/rc_receiver_main.cpp
@@ -101,7 +101,7 @@ static void start();
 static void stop();
 
 /** task main trampoline function */
-static void	task_main_trampoline(int argc, char *argv[]);
+static int	task_main_trampoline(int argc, char *argv[]);
 
 /** mpu9x50 measurement thread primary entry point */
 static void task_main(int argc, char *argv[]);
@@ -173,10 +173,11 @@ void stop()
 	_task_handle = -1;
 }
 
-void task_main_trampoline(int argc, char *argv[])
+int task_main_trampoline(int argc, char *argv[])
 {
 	PX4_WARN("task_main_trampoline");
 	task_main(argc, argv);
+	return 0;
 }
 
 void task_main(int argc, char *argv[])

--- a/src/drivers/qurt/fc_addon/uart_esc/uart_esc_main.cpp
+++ b/src/drivers/qurt/fc_addon/uart_esc/uart_esc_main.cpp
@@ -103,7 +103,7 @@ static void start(const char *device) __attribute__((unused));
 static void stop();
 
 /** task main trampoline function */
-static void	task_main_trampoline(int argc, char *argv[]);
+static int	task_main_trampoline(int argc, char *argv[]);
 
 /** uart_esc thread primary entry point */
 static void task_main(int argc, char *argv[]);
@@ -414,10 +414,11 @@ void task_main(int argc, char *argv[])
 }
 
 /** uart_esc main entrance */
-void task_main_trampoline(int argc, char *argv[])
+int task_main_trampoline(int argc, char *argv[])
 {
 	PX4_WARN("task_main_trampoline");
 	task_main(argc, argv);
+	return 0;
 }
 
 void start()

--- a/src/drivers/snapdragon_pwm_out/snapdragon_pwm_out.cpp
+++ b/src/drivers/snapdragon_pwm_out/snapdragon_pwm_out.cpp
@@ -133,7 +133,7 @@ static void pwm_deinitialize();
 
 static void send_outputs_pwm(const uint16_t *pwm);
 
-static void task_main_trampoline(int argc, char *argv[]);
+static int task_main_trampoline(int argc, char *argv[]);
 
 static void subscribe();
 
@@ -473,9 +473,10 @@ void task_main(int argc, char *argv[])
 	_is_running = false;
 }
 
-void task_main_trampoline(int argc, char *argv[])
+int task_main_trampoline(int argc, char *argv[])
 {
 	task_main(argc, argv);
+	return 0;
 }
 
 void start()

--- a/src/lib/parameters/flashparams/flashfs.c
+++ b/src/lib/parameters/flashparams/flashfs.c
@@ -101,7 +101,7 @@ typedef begin_packed_struct struct flash_entry_header_t {
                                                * Will result the offset of the next active file or
                                                * free space. */
 	flash_file_token_t   file_token;      /* file token type - essentially the name/type */
-} end_packed_struct flash_entry_header_t;
+} end_packed_struct flash_entry_header_t __attribute__ ((aligned (sizeof(uint32_t))));
 #pragma GCC diagnostic pop
 
 /****************************************************************************


### PR DESCRIPTION
Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by this pull request**
../../src/lib/parameters/flashparams/flashfs.c: In function 'blank_check':
../../src/lib/parameters/flashparams/flashfs.c:190:2: error: converting a packed 'flash_entry_header_t' {aka 'struct flash_entry_header_t'} pointer (alignment 1) to a 'uint32_t' {aka 'unsigned int'} pointer (alignment 4) may result in an unaligned pointer value [-Werror=address-of-packed-member]
  190 |  uint32_t *pm = (uint32_t *)(void*) pf;
      |  ^~~~~~~~
compilation terminated due to -Wfatal-errors.


**Describe your solution**
a typedef structure has to be aligned to the size of uint32_t. provided compiler alignment directive.

**Describe possible alternatives**
unknown alternatives.

**Test data / coverage**
tested compilation only.

**Additional context**
the ticket is unsolved
https://github.com/PX4/PX4-Autopilot/pull/12319
